### PR TITLE
(maint) Set resolve_reference task to private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Release 0.3.0
+
+### New features
+
+* **Set `resolve_reference` task to private** ([#6](https://github.com/puppetlabs/puppetlabs-azure_inventory/pulls/6))
+
+    The `resolve_reference` task has been set to `private` so it no longer appears in UI lists.
+
 ## Release 0.2.0
 
 **Changes**

--- a/tasks/resolve_reference.json
+++ b/tasks/resolve_reference.json
@@ -28,5 +28,6 @@
     "scale_set": {
       "type": "Optional[String[1]]"
     }
-  }
+  },
+  "private": true
 }


### PR DESCRIPTION
This sets the `resolve_reference` task to private so it doesn't appear
in a task list when using `bolt task show`.

Part of puppetlabs/bolt#1599