### PR TITLE
(bug) Add missing ruby_task_helper dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,27 @@
+## Release 0.4.0
+
+### New features
+
+* **Add debugging statements to task errors**
+  ([#9](https://github.com/puppetlabs/puppetlabs-azure_inventory/pull/9))
+
+  Error objects returned from the `resolve_reference` task now includes
+  debugging statements that describe the steps the task is taking under
+  the `details` key.
+
+### Bug fixes
+
+* **Add missing dependency to module metadata**
+  ([#10](https://github.com/puppetlabs/puppetlabs-azure_inventory/pull/9))
+
+  The module metadata now includes `ruby_plugin_helper` and `ruby_task_helper`
+  as dependencies.
+
 ## Release 0.3.0
 
 ### New features
 
-* **Set `resolve_reference` task to private** ([#6](https://github.com/puppetlabs/puppetlabs-azure_inventory/pulls/6))
+* **Set `resolve_reference` task to private** ([#6](https://github.com/puppetlabs/puppetlabs-azure_inventory/pull/6))
 
     The `resolve_reference` task has been set to `private` so it no longer appears in UI lists.
 

--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,10 @@
   "license": "Apache-2.0",
   "source": "git@github.com/puppetlabs/puppetlabs-azure_inventory",
   "dependencies": [
-
+    {
+      "name":"puppetlabs-ruby_task_helper",
+      "version_requirement":">= 0.5.1 < 1.0.0"
+    }
   ],
   "operatingsystem_support": [
     {


### PR DESCRIPTION
This adds `ruby_task_helper` as a dependency to the module metadata.