### PR TITLE
(BOLT-136) Bump ruby_task_helper upper bound to < 2.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,7 @@
   "dependencies": [
     {
       "name":"puppetlabs-ruby_task_helper",
-      "version_requirement":">= 0.5.1 < 1.0.0"
+      "version_requirement":">= 0.5.1 < 2.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
## Summary

Bumps the `ruby_task_helper` dependency upper bound in `metadata.json` from `< 1.0.0` to `< 2.0.0`, keeping the original lower bound: `>= 0.5.1 < 1.0.0` → `>= 0.5.1 < 2.0.0`.

## Background — BOLT-136

Bolt 5.x ships `ruby_task_helper 1.0.1` (pinned in bolt-private's Puppetfile). Modules that declare an upper bound of `< 1.0.0` on `ruby_task_helper` cause a dependency resolution failure when users run `bolt module install`:

```
Unable to resolve modules: Puppetfile Resolver could not find compatible versions
for possibility named "ruby_task_helper":
  puppetlabs-ruby_task_helper 1.0.1
  puppetlabs-azure_inventory depends on puppetlabs-ruby_task_helper >= 0.5.1 < 1.0.0
```

This blocks Puppet 8 / Bolt 5 users from installing any module bundle that includes this module alongside `ruby_task_helper >= 1.0.0`.

## Change

```diff
- "version_requirement": ">= 0.5.1 < 1.0.0"
+ "version_requirement": ">= 0.5.1 < 2.0.0"
```

The upper bound is bumped to `< 2.0.0` (SemVer-aligned) to unblock `ruby_task_helper` 1.x while still guarding against a hypothetical breaking 2.x release.

## How it was tested

### 1. Constraint verification (before fix)

Confirmed the constraint violation exists with the published Forge version:

```
$ bolt module install
Unable to resolve modules: Puppetfile Resolver could not find compatible versions
for possibility named "ruby_task_helper":
  puppetlabs-ruby_task_helper 1.0.1
  puppetlabs-azure_inventory depends on puppetlabs-ruby_task_helper >= 0.5.1 < 1.0.0
```

### 2. Cross-module Puppetfile resolution

Verified that all 5 affected modules resolve cleanly together with `ruby_task_helper 1.0.1` using bolt's Puppetfile resolver. This confirms no remaining constraint conflicts across the module set.

## Related PRs

This is one of 5 coordinated PRs across affected modules:
- `puppetlabs-azure_inventory` (this PR)
- [puppetlabs-gcloud_inventory #14](https://github.com/puppetlabs/puppetlabs-gcloud_inventory/pull/14)
- [puppetlabs-http_request #18](https://github.com/puppetlabs/puppetlabs-http_request/pull/18)
- [puppetlabs-vault #19](https://github.com/puppetlabs/puppetlabs-vault/pull/19)
- [puppetlabs-terraform #41](https://github.com/puppetlabs/puppetlabs-terraform/pull/41)

All apply the same change: bump the `ruby_task_helper` upper bound from `< 1.0.0` to `< 2.0.0`.